### PR TITLE
Feature/assessment

### DIFF
--- a/delivery/build.gradle
+++ b/delivery/build.gradle
@@ -45,6 +45,14 @@ dependencies {
 
     compile("com.epages.microservice.handson:shared:0.+")
     runtime("com.h2database:h2")
+    
+    //envers dependencies
+    compile("org.hibernate:hibernate-core:5.1.0.Final")
+    compile("org.hibernate:hibernate-entitymanager:5.1.0.Final")
+    compile("org.hibernate:hibernate-validator:5.1.0.Final")
+    compile("org.hibernate:hibernate-envers:5.1.0.Final")
+    compile("org.springframework.data:spring-data-envers:1.0.0.RELEASE")
+    //envers dependencies
 
     testCompile("org.springframework.boot:spring-boot-starter-test")
     testCompile("org.assertj:assertj-core:3.1.0")

--- a/delivery/src/main/java/com/epages/microservice/handson/delivery/DeliveryOrder.java
+++ b/delivery/src/main/java/com/epages/microservice/handson/delivery/DeliveryOrder.java
@@ -15,9 +15,12 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Table;
 
+import org.hibernate.envers.Audited;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 @Entity
+@Audited
 @Table(name = "DELIVERY_ORDER")
 public class DeliveryOrder implements Serializable {
 

--- a/delivery/src/test/java/com/epages/microservice/handson/delivery/DeliveryOrderControllerTest.java
+++ b/delivery/src/test/java/com/epages/microservice/handson/delivery/DeliveryOrderControllerTest.java
@@ -12,7 +12,6 @@ import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppC
 import java.net.URI;
 import java.net.URISyntaxException;
 
-import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;


### PR DESCRIPTION
As discussed, I am sending my solution to the micro-service assessment. 
I chose to enable auditing for the DeliveryOrder Entity via Hibernate Envers.
Unfortunately I couldn't get the project to work with Spring-Data-Envers and its RevisionRepository. 
When setting up a minimal project, however, I was able to work with Spring-Data-Envers. So I assume the reason it didn't work with the delivery-project lies in the configuration of the project itself.
As a result the DeliveryOrderRepositoryTest uses the standard hibernate AuditReader to retrieve the entity's revisions.

Kind regards,
Sebastian Dörl